### PR TITLE
Update favor for The Lost Gatekeeper quests

### DIFF
--- a/Data/Compendium/Quests.txt
+++ b/Data/Compendium/Quests.txt
@@ -672,35 +672,35 @@ Epic: 21
 QuestName: The Home of Memory
 Pack: The Lost Gatekeepers
 Patron: The Gatekeepers
-Favor: 9
+Favor: 3
 Level: 3
 Epic: 32
 
 QuestName: Heart of the Problem
 Pack: The Lost Gatekeepers
 Patron: The Gatekeepers
-Favor: 9
+Favor: 3
 Level: 3
 Epic: 32
 
 QuestName: Rosemary's Ballad
 Pack: The Lost Gatekeepers
 Patron: The Gatekeepers
-Favor: 9
+Favor: 3
 Level: 3
 Epic: 32
 
 QuestName: The Sacred Bounty
 Pack: The Lost Gatekeepers
 Patron: The Gatekeepers
-Favor: 6
+Favor: 2
 Level: 3
 Epic: 32
 
 QuestName: Housekeeping
 Pack: The Lost Gatekeepers
 Patron: The Gatekeepers
-Favor: 9
+Favor: 3
 Level: 3
 Epic: 32
 


### PR DESCRIPTION
The value listed in the compendium for The Lost Gatekeeper quests is three times the correct value. This pull request corrects those values