### PR TITLE
add skeletons in the closet raid and U59 updates

### DIFF
--- a/Data/Compendium/Quests.txt
+++ b/Data/Compendium/Quests.txt
@@ -1561,7 +1561,7 @@ Pack: The Isle of Dread
 Patron: The Gatekeepers
 Favor: 4
 Level: 7
-Epic: 32
+Epic: 33
 
 QuestName: The Curse and the Captive Crustacean
 Pack: The Isle of Dread

--- a/Data/Compendium/Quests.txt
+++ b/Data/Compendium/Quests.txt
@@ -459,16 +459,19 @@ QuestName: Diplomatic Impunity
 Patron: The Coin Lords
 Favor: 6
 Level: 12
+Epic: 34
 
 QuestName: Frame Work
 Patron: The Coin Lords
 Favor: 5
 Level: 12
+Epic: 34
 
 QuestName: Eyes of Stone
 Patron: The Coin Lords
 Favor: 6
 Level: 12
+Epic: 34
 
 QuestName: Invaders!
 Patron: The Coin Lords
@@ -2162,24 +2165,28 @@ Pack: Attack on Stormreach
 Patron: The Coin Lords
 Favor: 5
 Level: 13
+Epic: 34
 
 QuestName: Blockade Buster
 Pack: Attack on Stormreach
 Patron: The Coin Lords
 Favor: 5
 Level: 13
+Epic: 34
 
 QuestName: Undermine
 Pack: Attack on Stormreach
 Patron: The Coin Lords
 Favor: 5
 Level: 13
+Epic: 34
 
 QuestName: Siegebreaker
 Pack: Attack on Stormreach
 Patron: The Coin Lords
 Favor: 6
 Level: 13
+Epic: 34
 
 QuestName: Feast or Famine
 Pack: Ruins of Gianthold

--- a/Data/Compendium/Quests.txt
+++ b/Data/Compendium/Quests.txt
@@ -1637,6 +1637,14 @@ Favor: 4
 Level: 7
 Epic: 33
 
+QuestName: Skeletons in the Closet
+Pack: The Isle of Dread
+Patron: The Gatekeepers
+Favor: 10
+Level: 34
+Epic: 34
+Style: Raid
+
 QuestName: Slave Pits of the Undercity
 Pack: Against the Slave Lords
 Patron: The Gatekeepers

--- a/Data/Compendium/Tables.txt
+++ b/Data/Compendium/Tables.txt
@@ -1,7 +1,7 @@
 Table: Heroic
 Title: Experience Points to Level by Life
 Columns: 4
-Width: Level	9,999,999	9,999,999	9,999,999
+Width: Level	99,999,999	9,999,999	9,999,999
 Rows: 20
 Group: 4
 Header: Level	Champion	Hero	Legend
@@ -28,8 +28,8 @@ Row: 20	1900000	2850000	3800000
 
 Table: Epic
 Columns: 2
-Width: Level	9,999,999
-Rows: 10
+Width: Level	99,999,999
+Rows: 12
 Group: 10
 Row: 21	600000
 Row: 22	1250000
@@ -41,45 +41,16 @@ Row: 27	5250000
 Row: 28	6200000
 Row: 29	7200000
 Row: 30	8250000
+Row: 31	1600000
+Row: 32	3600000
 
-Table: Destiny
-Title: Epic Destinies
-Columns: 3
-Width: Level	9,999,999	999
-Style: TextCenter	Numeric	TextRight
-Rows: 30
-Group: 5
-Header: Level	XP	AP
-Row: 	36000	1
-Row: 	72000	2
-Row: 	108000	3
-Row: 	144000	4
-Row: 1	180000	
-Row: 	228000	5
-Row: 	276000	6
-Row: 	324000	7
-Row: 	372000	8
-Row: 2	420000	
-Row: 	480000	9
-Row: 	540000	10
-Row: 	600000	11
-Row: 	660000	12
-Row: 3	720000	
-Row: 	792000	13
-Row: 	864000	14
-Row: 	936000	15
-Row: 	1008000	16
-Row: 4	1080000	
-Row: 	1164000	17
-Row: 	1248000	18
-Row: 	1332000	19
-Row: 	1416000	20
-Row: 5	1500000	
-Row: 	1596000	21
-Row: 	1692000	22
-Row: 	1788000	23
-Row: 	1884000	24
-Row: Max	1980000	
+Table: Legendary
+Columns: 2
+Width: Level    99,999,999
+Rows: 2
+Group: 2
+Row: 31 1,600,000
+Row: 32 3,600,000
 
 Table: Fred
 Title: Feat Respec with Fred


### PR DESCRIPTION
Added listing for Skeletons in the Closet, L34 versions of the attack on stormreach pack and free quests

saving re-ordering the quests to match in-game naming for when I better understand the sort rules the game uses