### PR TITLE
Issue #44: Incorrect Patron Names

### DIFF
--- a/Data/Compendium/Quests.txt
+++ b/Data/Compendium/Quests.txt
@@ -3676,14 +3676,14 @@ Epic: 28
 
 QuestName: The Covered Culvert
 Pack: Tavern Tales
-Patron: The Harpers
+Patron: The Free Agents
 Favor: 3
 Level: 4
 Epic: 35
 
 QuestName: Sleeping with the Fishes
 Pack: Tavern Tales
-Patron: The Harpers
+Patron: The Free Agents
 Favor: 4
 Level: 3
 Epic: 35


### PR DESCRIPTION
Updated Patron information for 2 Tavern Tales quests that incorrectly related them to The Harper faction when they belong to The Free Agent faction.